### PR TITLE
Add `baseline` switch to `nyc instrument` command

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const tempDir = {
 	default: './.nyc_output',
 	nycAlias: 't',
 	nycHiddenAlias: 'temp-directory',
-	nycCommands: [null, 'check-coverage', 'merge', 'report']
+	nycCommands: [null, 'check-coverage', 'instrument', 'merge', 'report']
 };
 
 const testExclude = {
@@ -339,6 +339,12 @@ const instrumentOnly = {
 	},
 	completeCopy: {
 		description: 'should nyc copy all files from input to output as well as instrumented files?',
+		type: 'boolean',
+		default: false,
+		nycCommands: nycCommands.instrumentOnly
+	},
+	baseline: {
+		description: 'should nyc create a baseline coverage file?',
 		type: 'boolean',
 		default: false,
 		nycCommands: nycCommands.instrumentOnly

--- a/tap-snapshots/test-test.js-TAP.test.js
+++ b/tap-snapshots/test-test.js-TAP.test.js
@@ -76,6 +76,7 @@ Object {
   "all": false,
   "autoWrap": true,
   "babelCache": false,
+  "baseline": false,
   "branches": 0,
   "cache": true,
   "checkCoverage": false,


### PR DESCRIPTION
This PR is in support of a corresponding one coming for `nyc`.  See [here](https://github.com/istanbuljs/nyc/pull/1261)