### PR TITLE
feat: Add `cache...` options for instrument command

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,6 +247,21 @@ const report = {
 	}
 };
 
+const cache = {
+	cache: {
+		description: 'cache instrumentation results for improved performance',
+		type: 'boolean',
+		default: true,
+		nycCommands: nycCommands.instrument,
+		nycAlias: 'c'
+	},
+	cacheDir: {
+		description: 'explicitly set location for instrumentation cache',
+		type: 'string',
+		nycCommands: nycCommands.instrument
+	}
+};
+
 const nycMain = {
 	silent: {
 		description: 'don\'t output a report after tests finish running',
@@ -266,18 +281,6 @@ const nycMain = {
 		description: 'instantiate the instrumenter at startup (see https://git.io/vMKZ9)',
 		type: 'boolean',
 		default: false,
-		nycCommands: nycCommands.main
-	},
-	cache: {
-		description: 'cache instrumentation results for improved performance',
-		type: 'boolean',
-		default: true,
-		nycCommands: nycCommands.main,
-		nycAlias: 'c'
-	},
-	cacheDir: {
-		description: 'explicitly set location for instrumentation cache',
-		type: 'string',
 		nycCommands: nycCommands.main
 	},
 	babelCache: {
@@ -389,6 +392,9 @@ const nyc = {
 
 		/* Report options */
 		...report,
+
+		/* Cache options */
+		...cache,
 
 		/* Main command options */
 		...nycMain,


### PR DESCRIPTION
Makes the `cache` and `cacheDir` options available for the instrument command.

This change is a prerequisite to implementing this functionality in `nyc`.  There will be a PR in the `nyc` repo accompanying this PR.