### PR TITLE
fix: add `.pnp.*` files (used by yarn) to exclude list

### DIFF
--- a/default-exclude.js
+++ b/default-exclude.js
@@ -14,6 +14,9 @@ module.exports = [
 	`**/*{.,-}test.{${testFileExtensions}}`,
 	'**/__tests__/**',
 
+	/* Exclude yarn pnp resolver */
+	'.pnp.*',
+
 	/* Exclude common development tool configuration files */
 	'**/{ava,babel,nyc}.config.{js,cjs,mjs}',
 	'**/jest.config.{js,cjs,mjs,ts}',


### PR DESCRIPTION
More information about the generated files at https://yarnpkg.com/features/pnp#fixing-node_modules