### PR TITLE
Add default support for .cts and .mts file extensions

### DIFF
--- a/default-extension.js
+++ b/default-extension.js
@@ -6,5 +6,7 @@ module.exports = [
 	'.mjs',
 	'.ts',
 	'.tsx',
-	'.jsx'
+	'.jsx',
+	'.cts',
+	'.mts'
 ];


### PR DESCRIPTION
I ran in to the fact that jest isn't collecting coverage from .mts files when using babel-jest. It appears this already works in Istanbul but the files are currently excluded. Is there any reason to not include them in the default list of file extensions?